### PR TITLE
Remove circular dependencies for esm.sh build

### DIFF
--- a/packages/core/src/helpers/event-cache.ts
+++ b/packages/core/src/helpers/event-cache.ts
@@ -2,7 +2,7 @@ import { NostrEvent } from "./event.js";
 import { IEventStoreStreams } from "../event-store/interface.js";
 import { bufferTime, filter } from "rxjs";
 import { logger } from "../logger.js";
-import { isFromCache } from "./index.js";
+import { isFromCache } from "./event.js";
 
 const log = logger.extend("event-cache");
 

--- a/packages/core/src/helpers/profile.ts
+++ b/packages/core/src/helpers/profile.ts
@@ -1,6 +1,6 @@
 import { getOrComputeCachedValue } from "./cache.js";
-import { NostrEvent, kinds } from "./event.js";
-import { KnownEvent, safeParse } from "./index.js";
+import { KnownEvent, NostrEvent, kinds } from "./event.js";
+import { safeParse } from "./json.js";
 import { npubEncode } from "./pointers.js";
 
 export const ProfileContentSymbol = Symbol.for("profile-content");


### PR DESCRIPTION
## Problem

`applesauce-core@4.4.2/helpers` failed to bundle on esm.sh due to a circular dependency.

**Error:**
```
esbuild: No matching export in "node_modules/applesauce-core/dist/helpers/index.js" for import "isFromCache"
```

## Root Cause

Files imported from the barrel export (`./index.js`) while also being re-exported by it, creating a circular dependency that esbuild's static analysis cannot resolve.

## Changes Made

### `packages/core/src/helpers/event-cache.ts` (line 5)

```diff
- import { isFromCache } from "./index.js";
+ import { isFromCache } from "./event.js";
```

### `packages/core/src/helpers/profile.ts` (lines 2-3)

```diff
- import { KnownEvent, safeParse } from "./index.js";
+ import { KnownEvent, NostrEvent, kinds } from "./event.js";
+ import { safeParse } from "./json.js";
```