### PR TITLE
Fix parseReplaceableAddress to handle URLs with colons

### DIFF
--- a/packages/core/src/helpers/__tests__/tags.test.ts
+++ b/packages/core/src/helpers/__tests__/tags.test.ts
@@ -27,6 +27,16 @@ describe("processTags", () => {
     expect(result).toEqual([{ kind: 30000, pubkey: user.pubkey, identifier: "list" }]);
   });
 
+  it("should correctly parse urls as identifier", () => {
+    const result = processTags([["a", `30000:${user.pubkey}:https://identifier.org/`]], (t) => {
+      if (t[1] === "bad coordinate") throw new Error("Bad coordinate");
+      return getAddressPointerFromATag(t) ?? undefined;
+    });
+
+    expect(result).toEqual([{ kind: 30000, pubkey: user.pubkey, identifier: "https://identifier.org/" }]);
+  });
+
+
   it("should filter out undefined", () => {
     expect(
       processTags([["a", "bad coordinate"], ["e"], ["a", "30000:pubkey:list"]], (tag) =>

--- a/packages/core/src/helpers/pointers.ts
+++ b/packages/core/src/helpers/pointers.ts
@@ -74,13 +74,16 @@ export function parseReplaceableAddress(address: string, requireIdentifier = fal
   const parts = address.split(":") as (string | undefined)[];
   const kind = parts[0] ? parseInt(parts[0]) : undefined;
   const pubkey = parts[1];
-  const identifier = parts[2] ?? "";
 
   // Check valid kind
   if (kind === undefined) return null;
 
   // Check valid pubkey
   if (pubkey === undefined || pubkey === "" || !isHexKey(pubkey)) return null;
+
+  // Reconstruct identifier by joining all remaining parts after pubkey
+  // This handles cases where the identifier contains colons (e.g., URLs)
+  const identifier = parts.slice(2).join(":");
 
   // Return null if identifier is required and missing
   if (requireIdentifier && identifier === "") return null;


### PR DESCRIPTION
- Modified parseReplaceableAddress to properly parse identifiers containing colons
- Added test case to prevent regression
- Fixes issue with URL identifiers being truncated at first colon

Fixes https://github.com/hzrd149/applesauce/issues/41