### PR TITLE
fix: pool manual methods silently dropping offline relays

### DIFF
--- a/.changeset/chubby-bottles-push.md
+++ b/.changeset/chubby-bottles-push.md
@@ -1,0 +1,5 @@
+---
+"applesauce-relay": patch
+---
+
+Wait for non-ready relays to become ready in `RelayPool.group` instead of dropping them, and deprecate `RelayPool.ignoreOffline`

--- a/.changeset/chubby-bottles-push.md
+++ b/.changeset/chubby-bottles-push.md
@@ -2,4 +2,4 @@
 "applesauce-relay": patch
 ---
 
-Wait for non-ready relays to become ready in `RelayPool.group` instead of dropping them, and deprecate `RelayPool.ignoreOffline`
+Default `RelayPool.ignoreOffline` to `false` and deprecate the property. When the opt-in `ignoreOffline=true` path is used, `RelayPool.group` now waits for non-ready relays to become ready instead of dropping them.

--- a/packages/relay/src/pool.ts
+++ b/packages/relay/src/pool.ts
@@ -149,7 +149,8 @@ export class RelayPool {
     event: Parameters<RelayGroup["publish"]>[0],
     opts?: Parameters<RelayGroup["publish"]>[1],
   ): Promise<PublishResponse[]> {
-    return this.group(relays).publish(event, opts);
+    // Never filter out offline relays in manual methods
+    return this.group(relays, false).publish(event, opts);
   }
 
   /** Request events from multiple relays */
@@ -158,7 +159,8 @@ export class RelayPool {
     filters: Parameters<RelayGroup["request"]>[0],
     opts?: Parameters<RelayGroup["request"]>[1],
   ): Observable<NostrEvent> {
-    return this.group(relays).request(filters, opts);
+    // Never filter out offline relays in manual methods
+    return this.group(relays, false).request(filters, opts);
   }
 
   /** Open a subscription to multiple relays */
@@ -167,7 +169,8 @@ export class RelayPool {
     filters: Parameters<RelayGroup["subscription"]>[0],
     options?: Parameters<RelayGroup["subscription"]>[1],
   ): Observable<NostrEvent> {
-    return this.group(relays).subscription(filters, options);
+    // Never filter out offline relays in manual methods
+    return this.group(relays, false).subscription(filters, options);
   }
 
   /** Open a subscription for a map of relays and filters */
@@ -214,7 +217,8 @@ export class RelayPool {
     filters: Filter | Filter[],
     id?: string,
   ): Observable<Record<string, RelayCountResponse>> {
-    return this.group(relays).count(filters, id);
+    // Never filter out offline relays in manual methods
+    return this.group(relays, false).count(filters, id);
   }
 
   /** Negentropy sync events with the relays and an event store */
@@ -224,6 +228,7 @@ export class RelayPool {
     filter: Filter,
     direction?: SyncDirection,
   ): Observable<NostrEvent> {
-    return this.group(relays).sync(store, filter, direction);
+    // Never filter out offline relays in manual methods
+    return this.group(relays, false).sync(store, filter, direction);
   }
 }

--- a/packages/relay/src/pool.ts
+++ b/packages/relay/src/pool.ts
@@ -21,16 +21,16 @@ import {
 } from "rxjs";
 import { RelayGroup } from "./group.js";
 import type { NegentropySyncOptions, ReconcileFunction } from "./negentropy.js";
-import { Relay, SyncDirection, type RelayOptions } from "./relay.js";
+import { Relay, type RelayOptions, SyncDirection } from "./relay.js";
 import type {
-  RelayCountResponse,
   FilterInput,
-  GroupReqOptions,
   GroupReqMessage,
-  PoolRelayInput,
+  GroupReqOptions,
   NegentropyReadStore,
   NegentropySyncStore,
+  PoolRelayInput,
   PublishResponse,
+  RelayCountResponse,
   RelayStatus,
 } from "./types.js";
 
@@ -47,7 +47,7 @@ export class RelayPool {
    * Whether to ignore relays that are ready=false
    * @deprecated use {@link ignoreUnhealthyRelays} in group() or request() input
    */
-  ignoreOffline = true;
+  ignoreOffline = false;
 
   /** A signal when a relay is added */
   add$ = new Subject<Relay>();
@@ -144,14 +144,12 @@ export class RelayPool {
 
   /** Make a REQ to multiple relays that does not deduplicate events */
   req(relays: PoolRelayInput, filters: FilterInput, opts?: GroupReqOptions): Observable<GroupReqMessage> {
-    // Never filter out offline relays in manual methods
-    return this.group(relays, false).req(filters, opts);
+    return this.group(relays).req(filters, opts);
   }
 
   /** Send an EVENT message to multiple relays */
   event(relays: PoolRelayInput, event: NostrEvent): Observable<PublishResponse> {
-    // Never filter out offline relays in manual methods
-    return this.group(relays, false).event(event);
+    return this.group(relays).event(event);
   }
 
   /** Negentropy sync event ids with the relays and an event store */
@@ -162,7 +160,7 @@ export class RelayPool {
     reconcile: ReconcileFunction,
     opts?: NegentropySyncOptions,
   ): Promise<boolean> {
-    return this.group(relays, false).negentropy(store, filter, reconcile, opts);
+    return this.group(relays).negentropy(store, filter, reconcile, opts);
   }
 
   /** Publish an event to multiple relays */
@@ -171,8 +169,7 @@ export class RelayPool {
     event: Parameters<RelayGroup["publish"]>[0],
     opts?: Parameters<RelayGroup["publish"]>[1],
   ): Promise<PublishResponse[]> {
-    // Never filter out offline relays in manual methods
-    return this.group(relays, false).publish(event, opts);
+    return this.group(relays).publish(event, opts);
   }
 
   /** Request events from multiple relays */
@@ -181,8 +178,7 @@ export class RelayPool {
     filters: Parameters<RelayGroup["request"]>[0],
     opts?: Parameters<RelayGroup["request"]>[1],
   ): Observable<NostrEvent> {
-    // Never filter out offline relays in manual methods
-    return this.group(relays, false).request(filters, opts);
+    return this.group(relays).request(filters, opts);
   }
 
   /** Open a subscription to multiple relays */
@@ -191,8 +187,7 @@ export class RelayPool {
     filters: Parameters<RelayGroup["subscription"]>[0],
     options?: Parameters<RelayGroup["subscription"]>[1],
   ): Observable<NostrEvent> {
-    // Never filter out offline relays in manual methods
-    return this.group(relays, false).subscription(filters, options);
+    return this.group(relays).subscription(filters, options);
   }
 
   /** Open a subscription for a map of relays and filters */

--- a/packages/relay/src/pool.ts
+++ b/packages/relay/src/pool.ts
@@ -4,7 +4,9 @@ import { createFilterMap, FilterMap, OutboxMap } from "applesauce-core/helpers/r
 import { normalizeURL } from "applesauce-core/helpers/url";
 import {
   BehaviorSubject,
+  combineLatest,
   distinctUntilChanged,
+  filter,
   isObservable,
   map,
   merge,
@@ -15,6 +17,7 @@ import {
   startWith,
   Subject,
   switchMap,
+  take,
 } from "rxjs";
 import { RelayGroup } from "./group.js";
 import type { NegentropySyncOptions, ReconcileFunction } from "./negentropy.js";
@@ -40,7 +43,10 @@ export class RelayPool {
   /** Observable of relay status for all relays in the pool */
   status$: Observable<Record<string, RelayStatus>>;
 
-  /** Whether to ignore relays that are ready=false */
+  /**
+   * Whether to ignore relays that are ready=false
+   * @deprecated use {@link ignoreUnhealthyRelays} in group() or request() input
+   */
   ignoreOffline = true;
 
   /** A signal when a relay is added */
@@ -91,14 +97,30 @@ export class RelayPool {
 
   /** Create a group of relays */
   group(relays: PoolRelayInput, ignoreOffline = this.ignoreOffline): RelayGroup {
-    let input = Array.isArray(relays)
+    let input: Relay[] | Observable<Relay[]> = Array.isArray(relays)
       ? relays.map((url) => this.relay(url))
       : relays.pipe(map((urls) => urls.map((url) => this.relay(url))));
 
     if (ignoreOffline) {
-      // Filter out the offline relays
-      if (Array.isArray(input)) input = input.filter((relay) => relay.ready);
-      else input = input.pipe(map((relays) => relays.filter((relay) => relay.ready)));
+      // Convert input to an observable so it can react to relays becoming ready.
+      // Each relay is included once `ready$` first emits true, and stays included
+      // afterwards (subsequent ready=false changes are ignored since the request
+      // or subscription will have already started).
+      const input$ = Array.isArray(input) ? of(input) : input;
+      input = input$.pipe(
+        switchMap((relays) => {
+          if (relays.length === 0) return of([] as Relay[]);
+          const signals = relays.map((relay) =>
+            relay.ready$.pipe(
+              filter((ready) => ready),
+              take(1),
+              map(() => relay),
+              startWith(null as Relay | null),
+            ),
+          );
+          return combineLatest(signals).pipe(map((arr) => arr.filter((r): r is Relay => r !== null)));
+        }),
+      );
     }
 
     return new RelayGroup(input);


### PR DESCRIPTION
pool.subscription(), pool.request(), pool.publish(), pool.count(), and pool.sync() were calling group() without passing ignoreOffline=false. Since RelayPool.ignoreOffline defaults to true, any relay with ready=false (caused by a prior failed connection, network hiccup, etc.) was silently filtered out. The caller then hangs forever waiting for events/acks that can never arrive because no relay is actually subscribed.

Fix: pass ignoreOffline=false explicitly in all manual convenience methods, matching the existing pattern already used by req(), event(), and negentropy().

Fixes hzrd149/nostrudel#354